### PR TITLE
packaging_tools: avoid bashisms

### DIFF
--- a/content/posts/python/packaging_tools.md
+++ b/content/posts/python/packaging_tools.md
@@ -79,7 +79,7 @@ Many tools allow users to create and manage environments. These are: `venv, virt
 python3 -m venv <env_name>
 
 # Activate an environment
-source <env_name>/bin/activate
+. <env_name>/bin/activate
 
 # Deactivate an active environment
 deactivate
@@ -92,7 +92,7 @@ deactivate
 virtualenv <env_name>
 
 # Activate an environment
-source <env_name>/bin/activate
+. <env_name>/bin/activate
 
 # Deactivate an active environment
 deactivate


### PR DESCRIPTION
`source` only works for bash, while `.` is POSIX.

https://wiki.ubuntu.com/DashAsBinSh#source